### PR TITLE
Add in checks for checking number of absolute services being down

### DIFF
--- a/bin/check-haproxy.rb
+++ b/bin/check-haproxy.rb
@@ -1,4 +1,4 @@
-#! /usr/bin/env ruby
+#! /opt/sensu/embedded/bin ruby
 #
 #   check-haproxy.rb
 #


### PR DESCRIPTION
## What

Update check-haproxy.rb so that we can alert on absolute number of cherryd(s) being down.
## Why

Monetate requirement. We want to know if an absolute number of cherryd(s) are down.
## TODO
- [x] Test
- [x] Review
